### PR TITLE
Improve argument parsing

### DIFF
--- a/commandfinder.sh
+++ b/commandfinder.sh
@@ -27,7 +27,7 @@ usage() {
     echo 'usage: commandfinder commandname'
 }
 
-case $1 in
+case "$1" in
 -h|--help)
     usage
     exit

--- a/commandfinder.sh
+++ b/commandfinder.sh
@@ -23,12 +23,14 @@ preparecache() {
     fi
 }
 
-case "$1" in
---help)
+usage() {
     echo 'usage: commandfinder commandname'
-    ;;
--h)
-    echo 'usage: commandfinder commandname'
+}
+
+case $1 in
+-h|--help)
+    usage
+    exit
     ;;
 cache)
     mkdir "${2:-commandfindercache}"
@@ -37,6 +39,10 @@ cache)
     gencache
     exit
     ;;
+'')
+    echo 'commandfinder: requires an argument' >&2
+    usage >&2
+    exit 1
 esac
 
 echo -e "$(grep -o '[^/]*$' <<<"$SHELL"): command $1 not found\n"


### PR DESCRIPTION
Just a small improvement for the argument parsing `case` statement in `commandfinder.sh`.

- Consolidated the `-h` and `--help` cases into one
- Added a `usage` function to display usage text
- Fixed a couple bugs:
    - Providing no argument to `commandfinder` resulted in '$SHELL: command﻿﻿&nbsp;&nbsp;not found' (note two spaces after 'command'), which could potentially be confusing to users if they think their shell itself is throwing an error. Now, it explicitly requires an argument and makes clear that it's `commandfinder` throwing the error, not their shell.
    - The `-h|--help)` case(s) didn't exit after running, which meant it would try and find a command called `-h` or `--help` after the argument parsing section finished executing.